### PR TITLE
Remove leaked frontend tokens and use public APIs

### DIFF
--- a/docker/fe/docker-compose.yml
+++ b/docker/fe/docker-compose.yml
@@ -8,12 +8,10 @@ services:
       context: ../../services/fe   # percorso della cartella FE
       dockerfile: Dockerfile
       args:
-        REACT_APP_STRAPI_TOKEN: "119ce45f82e5433d98f67abcf90d393e787baea39122c99f5cfec5e958005e468bbec72d1353f5921bbe4a48d8eb915b0cd4d82bf7f923f3dcc010d3609ebaf53239c5cc191dec20bdf745b1be28179d38e0d5f5062f1f62da81bde9ad807388c3b9e42f45a170d54b22568e56b74515c7e1fa80d603b53689e1e1d419d175e2"
-        REACT_APP_STRAPI_API_URL: "http://strapi.mongipi.abrdns.com"
-        REACT_APP_SANTO_DEL_GIORNO_API_TOKEN: "351|ityfM1cWOpQPay0l0EHlO5PD4Eb7B2ROxagTExggc32337a0"
+        REACT_APP_STRAPI_API_URL: ${REACT_APP_STRAPI_API_URL:?}
     container_name: fe
     restart: unless-stopped
     networks:
       - reverse-proxy
     ports:
-      - "3000:3000"  
+      - "3000:3000"

--- a/services/fe/src/api/articoli.js
+++ b/services/fe/src/api/articoli.js
@@ -1,33 +1,23 @@
+import { fetchStrapi } from "./client";
+
 export async function getAllArticoli() {
-const now = new Date().toISOString();
-  const res = await fetch(
-`${process.env.REACT_APP_STRAPI_API_URL}/api/articolis?populate=*&filters[pubblicato_il][$lte]=${encodeURIComponent(now)}&filters[publishedAt][$notNull]=true&sort=pubblicato_il:desc`,
-    {
-      headers: {
-        Authorization: `Bearer ${process.env.REACT_APP_STRAPI_TOKEN}`,
-      },
-    }
-  );
+  const now = new Date().toISOString();
+  const query = `/api/articolis?populate=*&filters[pubblicato_il][$lte]=${encodeURIComponent(
+    now
+  )}&filters[publishedAt][$notNull]=true&sort=pubblicato_il:desc`;
+
+  const res = await fetchStrapi(query);
 
   if (!res.ok) throw new Error("Errore nel recupero articoli");
 
-  const response = await res.json();
-  return response;
+  return res.json();
 }
 
 export async function getArticoloById(id) {
-  const res = await fetch(
-    `${process.env.REACT_APP_STRAPI_API_URL}/api/articolis/${id}?populate=*`,
-    {
-      headers: {
-        Authorization: `Bearer ${process.env.REACT_APP_STRAPI_TOKEN}`,
-      },
-    }
-  );
+  const res = await fetchStrapi(`/api/articolis/${id}?populate=*`);
 
   if (!res.ok) throw new Error("Errore nel recupero dell'articolo");
 
-  const response = await res.json();
-  return response;
+  return res.json();
 }
 

--- a/services/fe/src/api/categorie.js
+++ b/services/fe/src/api/categorie.js
@@ -1,15 +1,9 @@
+import { fetchStrapi } from "./client";
+
 export async function getAllCategorie() {
-  const res = await fetch(
-    `${process.env.REACT_APP_STRAPI_API_URL}/api/categories?populate=*`,
-    {
-      headers: {
-        Authorization: `Bearer ${process.env.REACT_APP_STRAPI_TOKEN}`,
-      },
-    }
-  );
+  const res = await fetchStrapi("/api/categories?populate=*");
 
   if (!res.ok) throw new Error("Errore nel recupero delle categorie");
 
-  const response = await res.json();
-  return response;
+  return res.json();
 }

--- a/services/fe/src/api/client.js
+++ b/services/fe/src/api/client.js
@@ -1,0 +1,19 @@
+const STRAPI_API_URL = (process.env.REACT_APP_STRAPI_API_URL || "").replace(/\/$/, "");
+
+function normalizePath(path) {
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+
+  const ensuredLeadingSlash = path.startsWith("/") ? path : `/${path}`;
+  return `${STRAPI_API_URL}${ensuredLeadingSlash}`;
+}
+
+export function buildStrapiUrl(path) {
+  return normalizePath(path);
+}
+
+export async function fetchStrapi(path, fetchOptions = {}) {
+  const response = await fetch(normalizePath(path), fetchOptions);
+  return response;
+}

--- a/services/fe/src/api/farmacie.js
+++ b/services/fe/src/api/farmacie.js
@@ -1,18 +1,14 @@
+import { fetchStrapi } from "./client";
+
 export async function getFarmaciaTurno() {
-     const today = new Date().toISOString().split("T")[0]; 
-     
-    const res = await fetch(
-    
-    `${process.env.REACT_APP_STRAPI_API_URL}/api/oraris?filters[turno][$eq]=${today}&populate=farmacia`,
-    {
-      headers: {
-        Authorization: `Bearer ${process.env.REACT_APP_STRAPI_TOKEN}`,
-      },
-    }
+  const today = new Date().toISOString().split("T")[0];
+
+  const res = await fetchStrapi(
+    `/api/oraris?filters[turno][$eq]=${today}&populate=farmacia`
   );
 
   if (!res.ok) throw new Error("Errore nel recupero delle categorie");
 
-  const response = await res.json();
-  return response;
+  return res.json();
 }
+

--- a/services/fe/src/api/santo.js
+++ b/services/fe/src/api/santo.js
@@ -1,22 +1,15 @@
 export async function getSantoDelGiorno() {
   const now = new Date();
-const mese = now.getMonth() + 1; // numero, es. 3
-const giorno = now.getDate();    // numero, es. 8
+  const mese = now.getMonth() + 1; // numero, es. 3
+  const giorno = now.getDate(); // numero, es. 8
 
   const url = `https://santodelgiorno.mintdev.me/api/v1/santo/data/${mese}/${giorno}`;
 
-  const res = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${process.env.REACT_APP_SANTO_DEL_GIORNO_API_TOKEN}`,
-    },
-  });
+  const res = await fetch(url);
 
   if (!res.ok) {
     throw new Error("Errore nel recupero del santo del giorno");
   }
 
-  const response = await res.json();
-
-
-  return response;
+  return res.json();
 }


### PR DESCRIPTION
## Summary
- replace hard-coded frontend build tokens with deployment-provided Strapi URL configuration
- add a shared Strapi client helper and refactor API modules to rely on public content without bearer tokens
- fetch the Santo del Giorno data without embedding the compromised API key in the browser

## Testing
- npm install *(fails: npm error 403 Forbidden - registry access blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d127084c408332a35070f84b46025b